### PR TITLE
Fix detection of MultiROM ROM DIR

### DIFF
--- a/MultiROMMgr/src/main/java/com/tassadar/multirommgr/MultiROM.java
+++ b/MultiROMMgr/src/main/java/com/tassadar/multirommgr/MultiROM.java
@@ -57,6 +57,7 @@ public class MultiROM {
     public boolean findMultiROMDir() {
         List<String> out = Shell.SU.run(
                 "folders=\"/data/media/0/multirom/ /data/media/multirom/\";" +
+                "folders=\"/data/media/0/MultiROM/multirom/ /data/media/MultiROM/multirom/\";" +
                 "for f in $folders; do" +
                 "    if [ -d \"$f\" ]; then" +
                 "        echo \"$f\";" +


### PR DESCRIPTION
Since https://github.com/AdrianDC/multirom_core/commit/ebb4317a70e3056f6840e4576c895de08cb3d507 the path are change for MultiROM folders.
Fix this path for MultiROMMgr detection